### PR TITLE
Better log file timestamps

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -3,7 +3,7 @@
  */
 #include <sys/types.h>
 #include <stdio.h>
-#include <unistd.h>  
+#include <unistd.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <stdarg.h>
@@ -27,7 +27,8 @@ void log_string(const char *txt, ...)
   FILE *fp;
   char logfile[MAX_BUFFER];
   char buf[MAX_BUFFER];
-  char *strtime = get_time();
+  char *strtime = get_timestamp();
+  char *strdate = get_date();
   va_list args;
 
   va_start(args, txt);
@@ -35,7 +36,7 @@ void log_string(const char *txt, ...)
   va_end(args);
 
   /* point to the correct logfile */
-  snprintf(logfile, MAX_BUFFER, "../log/%6.6s.log", strtime);
+  snprintf(logfile, MAX_BUFFER, "../log/%s.log", strdate);
 
   /* try to open logfile */
   if ((fp = fopen(logfile, "a")) == NULL)
@@ -61,7 +62,7 @@ void bug(const char *txt, ...)
   FILE *fp;
   char buf[MAX_BUFFER];
   va_list args;
-  char *strtime = get_time();
+  char *strtime = get_timestamp();
 
   va_start(args, txt);
   vsnprintf(buf, MAX_BUFFER, txt, args);
@@ -279,7 +280,7 @@ char *fread_word(FILE *fp)
   int c, count = 0;
 
   /* initial read */
-  c = getc(fp); 
+  c = getc(fp);
 
   /* speed through leading spaces and linebreaks */
   while (c != EOF && (c == ' ' || c == '\n'))

--- a/src/mud.h
+++ b/src/mud.h
@@ -189,7 +189,7 @@ extern  char        *   motd;             /* the MOTD help file                 
 extern  int             control;          /* boot control socket thingy         */
 extern  time_t          current_time;     /* let's cut down on calls to time()  */
 
-/*************************** 
+/***************************
  * End of Global Variables *
  ***************************/
 
@@ -255,7 +255,7 @@ char   *fread_string          ( FILE *fp );                 /* allocated data  *
 char   *fread_word            ( FILE *fp );                 /* pointer         */
 int     fread_number          ( FILE *fp );                 /* just an integer */
 
-/* 
+/*
  * strings.c
  */
 char   *one_arg               ( char *fStr, char *bStr );
@@ -283,7 +283,8 @@ void  clear_mobile            ( D_M *dMob );
 void  free_mobile             ( D_M *dMob );
 void  communicate             ( D_M *dMob, char *txt, int range );
 void  load_muddata            ( bool fCopyOver );
-char *get_time                ( void );
+char *get_timestamp           ( void );
+char *get_date                ( void );
 void  copyover_recover        ( void );
 D_M  *check_reconnect         ( char *player );
 


### PR DESCRIPTION
This PR changes log file naming convention to the standard `YYYY-MM-DD` date format and the timestamps within the log files and bug list to the standard `YYYY-MM-DD HH:MM:SS` format.