### PR TITLE
Feature/testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: c
 
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: osx
 
 compiler: gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+
+os:
+  - linux
+  - osx
+
+compiler: gcc
+
+install: make zlib1g-dev
+
+script:
+  - cd src
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      addons:
+        apt:
+          packages:
+            - zlib1g-dev
     - os: osx
 
 compiler: gcc
-
-install: make zlib1g-dev
 
 script:
   - cd src

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC      = gcc
-C_FLAGS = -Wall -g -pedantic
+C_FLAGS = -Wall -g -pedantic -Werror
 L_FLAGS = -lz -lpthread -lcrypt
 
 O_FILES = socket.o io.o strings.o utils.o interpret.o help.o  \


### PR DESCRIPTION
This PR adds Travis-CI support. Since we don't actually have a test suite, all it does is verify that the binary can be compiled on both Ubuntu and OSX.

Additionally, to keep things as clean as possible, I added `-Werror` to the Makefile's `CFLAGS`. I would rather treat all warnings as errors and ignore or squash specific warnings that we agree aren't problematic.