### PR TITLE
Move the Makefile to the root of the project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ guildmud
 .vscode/tasks.json
 *.log
 .vscode/settings.json
+src/libguildmud.a

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+CC      = gcc
+C_FLAGS = -Wall -g -pedantic -Werror
+L_FLAGS = -lz -lpthread -lsqlite3
+
+SRC_FILES = $(wildcard src/*.c)
+OBJ_FILES = $(filter-out src/main.o, $(SRC_FILES:.c=.o))
+
+
+all: src/main.o src/libguildmud.a
+	$(CC) -o src/guildmud src/main.o src/libguildmud.a $(L_FLAGS)
+
+src/libguildmud.a: $(OBJ_FILES)
+	ar ru $@ $^
+	ranlib $@
+
+.c.o: all
+	$(CC) -c $(C_FLAGS) -o $@ $<
+
+clean:
+	@echo Cleaning code $< ...
+	@rm -f src/*.o src/guildmud src/libguildmud.a src/*~
+
+test:
+	@echo To be implemented shortly...
+
+install:
+	@echo To be implemented shortly...

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,20 +1,12 @@
-CC      = gcc
-C_FLAGS = -Wall -g -pedantic -Werror
-L_FLAGS = -lz -lpthread -lsqlite3
-
-O_FILES = main.o socket.o io.o strings.o utils.o interpret.o help.o  \
-	  action_safe.o mccp.o save.o event.o event-handler.o \
-	  list.o stack.o crypt.o db.o
+# This file will be deprecated shortly, please use the Makefile in 
+# the root file.
 
 all: $(O_FILES)
-	rm -f guildmud
-	$(CC) -o guildmud $(O_FILES) $(L_FLAGS)
-
-.c.o: all
-	@$(CC) -c $(C_FLAGS) $<
-
+	@echo This src/Makefile will be deprecated shortly.
+	@echo Please use the Makefile in the root project file.
+	@cd .. && $(MAKE)
+	
 clean:
-	@echo Cleaning code $< ...
-	@rm -f *.o
-	@rm -f guildmud
-	@rm -f *.*~
+	@echo This src/Makefile will be deprecated shortly.
+	@echo Please use the Makefile in the root project file.
+	@cd .. && $(MAKE) clean


### PR DESCRIPTION
To make easier the set up of tests, moved the Makefile to the project root.

The new Makefile in the root not compiles all the .c files (except main.c) to a library libguildmud.a that will allow test to link it directly.

Also, not to impact the current build process, the src/Makefile calls Makefile printing a message saying the previous Makefile will be deprecated in the future.
 