### PR TITLE
Add rc check so we don't segfault when help directory doesn't exist.

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -106,7 +106,11 @@ void load_helps()
 
   help_list = AllocList();
 
-  directory = opendir("../help/");
+  if((directory = opendir("../help/")) == NULL)
+  {
+    bug("Failed to open help directory");
+    abort();   
+  }
   for (entry = readdir(directory); entry; entry = readdir(directory))
   {
     if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))


### PR DESCRIPTION
Add a rc check in when opening the help dir to check if it exists. It closes [Issue #7](https://github.com/mudcoders/guildmud/issues/7).

If it doesn't exists, logs the bug in log/bug.txt and aborts().