### PR TITLE
Add testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ guildmud
 *.log
 .vscode/settings.json
 src/libguildmud.a
+tests/*.run

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC      = gcc
-C_FLAGS = -Wall -pedantic -Werror
+C_FLAGS = -Wall -pedantic -Werror -g
 L_FLAGS = -lz -lpthread -lsqlite3
-C_FLAGS_TEST = -Wall -pedantic -Werror -Isrc/
+C_FLAGS_TEST = -Wall -pedantic -Werror -g -Isrc/
 L_FLAGS_TEST = -lz -lpthread -lsqlite3 -lcheck -Lsrc/
 
 SRC_FILES = $(wildcard src/*.c)

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,40 @@
 CC      = gcc
-C_FLAGS = -Wall -g -pedantic -Werror
+C_FLAGS = -Wall -pedantic -Werror
 L_FLAGS = -lz -lpthread -lsqlite3
+C_FLAGS_TEST = -Wall -pedantic -Werror -Isrc/
+L_FLAGS_TEST = -lz -lpthread -lsqlite3 -lcheck -Lsrc/
 
 SRC_FILES = $(wildcard src/*.c)
 OBJ_FILES = $(filter-out src/main.o, $(SRC_FILES:.c=.o))
-
+CHECK_FILES = $(wildcard tests/*.test)
+CHECK_FILES_EXE = $(CHECK_FILES:.test=.run)
 
 all: src/main.o src/libguildmud.a
-	$(CC) -o src/guildmud src/main.o src/libguildmud.a $(L_FLAGS)
+	@$(CC) -o src/guildmud src/main.o src/libguildmud.a $(L_FLAGS)
 
 src/libguildmud.a: $(OBJ_FILES)
-	ar ru $@ $^
-	ranlib $@
+	@ar ru $@ $^
+	@ranlib $@
 
 .c.o: all
-	$(CC) -c $(C_FLAGS) -o $@ $<
+	@$(CC) -c $(C_FLAGS) -o $@ $<
 
-clean:
-	@echo Cleaning code $< ...
-	@rm -f src/*.o src/guildmud src/libguildmud.a src/*~
 
-test:
-	@echo To be implemented shortly...
+test: $(CHECK_FILES_EXE)
+	@echo Compiling tests...
+	
+
+tests/%.run: tests/%.c src/libguildmud.a
+	@$(CC) -o $@ $< src/libguildmud.a $(C_FLAGS_TEST) $(L_FLAGS_TEST) 
+	# $@ -- Uncomment if we want to run the compiled test
+
+tests/%.c: tests/%.test
+	@checkmk $< > $@
 
 install:
 	@echo To be implemented shortly...
+
+.PHONY: clean
+clean:
+	@echo Cleaning code ...
+	@rm -rf src/*.o src/guildmud src/libguildmud.a src/*~ tests/*.c tests/run* tests/*.dSYM src/*.dSYM

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "vagrant/provisioners/home.sh"
   config.vm.provision "shell", path: "vagrant/provisioners/c.sh"
   config.vm.provision "shell", path: "vagrant/provisioners/sqlite.sh"
+  config.vm.provision "shell", path: "vagrant/provisioners/check.sh"
 
   # make /vagrant the working directory for all commands
   config.exec.commands '*', directory: '/vagrant'

--- a/tests/test_crypt.test
+++ b/tests/test_crypt.test
@@ -1,0 +1,17 @@
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <check.h>
+
+#include "mud.h"
+
+#suite crypt_c
+#tcase check_is_prefix
+
+#test crypt_code_salt
+    ck_assert_str_eq("sanem1WDqdnxo", crypt("code", "salt"));
+#test crypt_guildmud_cprogramming
+    ck_assert_str_eq("cp.kzgf79whuQ", crypt("guildmud", "cprogramming"));

--- a/tests/test_strings.test
+++ b/tests/test_strings.test
@@ -1,0 +1,23 @@
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <check.h>
+
+#include "mud.h"
+
+#suite strings_c
+#tcase check_is_prefix
+
+#test is_prefix_A_A
+    ck_assert_msg(TRUE == is_prefix("A", "A"), "is_prefix A, A should have returned true");
+#test is_prefix_A_AA
+    ck_assert_msg(TRUE == is_prefix("A", "AA"), "is_prefix A, AA should have returned true");
+#test is_prefix_A_AAA
+    ck_assert_msg(TRUE == is_prefix("A", "AAA"), "is_prefix A, AAA should have returned true");
+#test is_prefix_A_AAAZ
+    ck_assert_msg(TRUE == is_prefix("A", "AAAZ"), "is_prefix A, AAAZ should have returned true");
+#test is_prefix_A_B_fail
+    ck_assert_msg(TRUE != is_prefix("A", "B"), "is_prefix A, B should have returned false");

--- a/tests/test_utils.test
+++ b/tests/test_utils.test
@@ -1,0 +1,27 @@
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <check.h>
+
+#include "mud.h"
+
+#suite utils_c
+#tcase check_name
+
+#test check_name_valid
+    ck_assert_msg(TRUE == check_name("abc"), "check_name abc must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(TRUE == check_name("ALFA"), "check_name ALFA must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(TRUE == check_name("OMEGA"), "check_name OMEGA must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(TRUE == check_name("first"), "check_name first must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(TRUE == check_name("second"), "check_name second must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(TRUE == check_name("abcdefghijkl"), "check_name abcdefghijkl must not fail is an alpha string >=3 and <=12");
+
+#test check_name_fail
+    ck_assert_msg(FALSE == check_name("guild mud"), "check_name /guild mud/ must fail because has an /space/");
+    ck_assert_msg(FALSE == check_name("ab"), "check_name /ab/ must fail because has less < 3 characters");
+    ck_assert_msg(FALSE == check_name("abcdefghijklm"), "check_name /abcdefghijklm/ must fail because has > 13 chars");
+    ck_assert_msg(FALSE == check_name("guild*mud"), "check_name /guild*mud/ must fail because has an /*/");
+    ck_assert_msg(FALSE == check_name("guild1mud"), "check_name /guild1mud/ must fail because has an /1/");

--- a/vagrant/provisioners/check.sh
+++ b/vagrant/provisioners/check.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt-get update
+apt-get install check


### PR DESCRIPTION
Some small steps to add testing infrastructure to close [Issue #11](https://github.com/mudcoders/guildmud/issues/11):

1. For the tests to run [Check](https://libcheck.github.io/check/) needs to be installed in your OS or vagrant.
2. Tests should be written in the $(ROOT)/tests/ directory using the [check syntax.
](https://stackoverflow.com/questions/14176180/is-there-a-more-basic-tutorial-for-the-c-unit-testing-framework-check) Additional info can be found reading the man page:
```shell
# man checkmk
```
3. Also, tests can be coded directly in C in $(ROOT)/tests/ directory, no problem with that. I plan to add a sample shortly, but if you do it before me and the Makefile is unable to compile them, please open an issue and I'll check.
4. Test samples are fairly inconsequential :)
5. The Makefile doesn't run the tests, this has to be done manually or via CI running the binaries compiled by the Makefile in $(ROOT)/tests/ directory. They can be identified by the .run extension. @zachflower can you add them to Travis CI?
