### PR TITLE
Remove unsafe strncpy and use safer snprintf.

### DIFF
--- a/src/action_safe.c
+++ b/src/action_safe.c
@@ -156,7 +156,7 @@ void cmd_copyover(D_MOBILE *dMob, char *arg)
     return;
   }
 
-  strncpy(buf, "\n\r <*>            The world starts spinning             <*>\n\r", MAX_BUFFER);
+  snprintf(buf, sizeof(buf), "%s", "\n\r <*>            The world starts spinning             <*>\n\r");
 
   /* For each playing descriptor, save its state */
   AttachIterator(&Iter, dsock_list);


### PR DESCRIPTION
Minor change to use snprintf. 

It was the only strncpy in the code, but snprintf was already used in other source files.