### PR TITLE
Add malloc castings to all the mallocs that needed them

### DIFF
--- a/src/event-handler.c
+++ b/src/event-handler.c
@@ -101,7 +101,7 @@ EVENT_DATA *alloc_event()
   EVENT_DATA *event;
 
   if (StackSize(event_free) <= 0)
-    event = malloc(sizeof(*event));
+    event = (EVENT_DATA *) malloc(sizeof(*event));
   else
     event = (EVENT_DATA *) PopStack(event_free);
 

--- a/src/help.c
+++ b/src/help.c
@@ -73,7 +73,7 @@ bool check_help(D_MOBILE *dMob, char *helpfile)
       return FALSE;
     else
     {
-      if ((pHelp = malloc(sizeof(*pHelp))) == NULL)
+      if ((pHelp = (HELP_DATA *) malloc(sizeof(*pHelp))) == NULL)
       { 
         bug("Check_help: Cannot allocate memory.");
         abort();
@@ -125,7 +125,7 @@ void load_helps()
       continue;
     }
 
-    if ((new_help = malloc(sizeof(*new_help))) == NULL)
+    if ((new_help = (HELP_DATA *) malloc(sizeof(*new_help))) == NULL)
     {
       bug("Load_helps: Cannot allocate memory.");
       abort();

--- a/src/list.c
+++ b/src/list.c
@@ -16,7 +16,7 @@ LIST *AllocList()
 {
   LIST *pList;
 
-  pList = malloc(sizeof(*pList));
+  pList = (LIST *) malloc(sizeof(*pList));
   pList->_pFirstCell = NULL;
   pList->_pLastCell = NULL;
   pList->_iterators = 0;
@@ -43,7 +43,7 @@ CELL *AllocCell()
 {
   CELL *pCell;
 
-  pCell = malloc(sizeof(*pCell));
+  pCell = (CELL *) malloc(sizeof(*pCell));
   pCell->_pNextCell = NULL;
   pCell->_pPrevCell = NULL;
   pCell->_pContent = NULL;

--- a/src/save.c
+++ b/src/save.c
@@ -35,7 +35,7 @@ D_MOBILE *load_player(char *player)
   /* create new mobile data */
   if (StackSize(dmobile_free) <= 0)
   {
-    if ((dMob = malloc(sizeof(*dMob))) == NULL)
+    if ((dMob = (D_MOBILE *) malloc(sizeof(*dMob))) == NULL)
     {
       bug("Load_player: Cannot allocate memory.");
       abort();
@@ -90,7 +90,7 @@ D_MOBILE *load_profile(char *player)
   /* create new mobile data */
   if (StackSize(dmobile_free) <= 0)
   {
-    if ((dMob = malloc(sizeof(*dMob))) == NULL)
+    if ((dMob = (D_MOBILE *) malloc(sizeof(*dMob))) == NULL)
     {
       bug("Load_player: Cannot allocate memory.");
       abort();

--- a/src/socket.c
+++ b/src/socket.c
@@ -248,7 +248,7 @@ bool new_socket(int sock)
    */
   if (StackSize(dsock_free) <= 0)
   {
-    if ((sock_new = malloc(sizeof(*sock_new))) == NULL)
+    if ((sock_new = (D_SOCKET*) malloc(sizeof(*sock_new))) == NULL)
     {
       bug("New_socket: Cannot allocate memory for socket.");
       abort();
@@ -286,7 +286,7 @@ bool new_socket(int sock)
     if (strcasecmp(sock_new->hostname, "127.0.0.1"))
     {
       /* allocate some memory for the lookup data */
-      if ((lData = malloc(sizeof(*lData))) == NULL)
+      if ((lData = (LOOKUP_DATA *) malloc(sizeof(*lData))) == NULL)
       {
         bug("New_socket: Cannot allocate memory for lookup data.");
         abort();
@@ -847,7 +847,7 @@ void handle_new_connections(D_SOCKET *dsock, char *arg)
       {
         if (StackSize(dmobile_free) <= 0)
         {
-          if ((p_new = malloc(sizeof(*p_new))) == NULL)
+          if ((p_new = (D_MOBILE *) malloc(sizeof(*p_new))) == NULL)
           {
             bug("Handle_new_connection: Cannot allocate memory.");
             abort();

--- a/src/stack.c
+++ b/src/stack.c
@@ -26,7 +26,7 @@ STACK *AllocStack()
 {
   STACK *pStack;
 
-  pStack = malloc(sizeof(*pStack));
+  pStack = (STACK *) malloc(sizeof(*pStack));
   pStack->_pCells = NULL;
   pStack->_iSize = 0;
 
@@ -68,7 +68,7 @@ void PushStack(void *pContent, STACK *pStack)
 {
   SCELL *pCell;
 
-  pCell = malloc(sizeof(*pCell));
+  pCell = (SCELL *) malloc(sizeof(*pCell));
   pCell->_pNext = pStack->_pCells;
   pCell->_pContent = pContent;
   pStack->_pCells = pCell;

--- a/src/strings.c
+++ b/src/strings.c
@@ -90,9 +90,9 @@ BUFFER *__buffer_new(int size)
 {
   BUFFER *buffer;
     
-  buffer = malloc(sizeof(BUFFER));
+  buffer = (BUFFER *) malloc(sizeof(BUFFER));
   buffer->size = size;
-  buffer->data = malloc(size);
+  buffer->data = (char *) malloc(size);
   buffer->len = 0;
   return buffer;
 }
@@ -122,7 +122,7 @@ void __buffer_strcat(BUFFER *buffer, const char *text)
     new_size = buffer->size + text_len + 1;
    
     /* Allocate the new buffer */
-    new_data = malloc(new_size);
+    new_data = (char *) malloc(new_size);
   
     /* Copy the current buffer to the new buffer */
     memcpy(new_data, buffer->data, buffer->len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -162,7 +162,7 @@ void copyover_recover()
     if (desc == -1)
       break;
 
-    dsock = malloc(sizeof(*dsock));
+    dsock = (D_SOCKET *) malloc(sizeof(*dsock));
     clear_socket(dsock, desc);
 
     dsock->hostname     =  strdup(host);


### PR DESCRIPTION
Minor change, but impacting a bunch of files.

Some mallocs did not cast the right pointer, so added them so all the source code mallocs now have the right casting. This was also identified by the linter.