### PR TITLE
Remove strcasecmp strdup from codebase

### DIFF
--- a/src/mud.h
+++ b/src/mud.h
@@ -265,7 +265,6 @@ int     fread_number          ( FILE *fp );                 /* just an integer *
  * strings.c
  */
 char   *one_arg               ( char *fStr, char *bStr );
-char   *strdup                ( const char *s );
 bool    is_prefix             ( const char *aStr, const char *bStr );
 char   *capitalize            ( char *txt );
 BUFFER *__buffer_new          ( int size );

--- a/src/mud.h
+++ b/src/mud.h
@@ -266,7 +266,6 @@ int     fread_number          ( FILE *fp );                 /* just an integer *
  */
 char   *one_arg               ( char *fStr, char *bStr );
 char   *strdup                ( const char *s );
-int     strcasecmp            ( const char *s1, const char *s2 );
 bool    is_prefix             ( const char *aStr, const char *bStr );
 char   *capitalize            ( char *txt );
 BUFFER *__buffer_new          ( int size );

--- a/src/strings.c
+++ b/src/strings.c
@@ -185,30 +185,3 @@ char *strdup(const char *s)
 
   return pstr;
 }
-
-int strcasecmp(const char *s1, const char *s2)
-{
-  int i = 0;
-
-  while (s1[i] != '\0' && s2[i] != '\0' && toupper(s1[i]) == toupper(s2[i]))
-    i++;
-
-  /* if they matched, return 0 */
-  if (s1[i] == '\0' && s2[i] == '\0')
-    return 0;
-
-  /* is s1 a prefix of s2? */
-  if (s1[i] == '\0')
-    return -110;
-
-  /* is s2 a prefix of s1? */
-  if (s2[i] == '\0')
-    return 110;
-
-  /* is s1 less than s2? */
-  if (toupper(s1[i]) < toupper(s2[i]))
-    return -1;
-
-  /* s2 is less than s1 */
-  return 1;
-}

--- a/src/strings.c
+++ b/src/strings.c
@@ -173,15 +173,3 @@ int bprintf(BUFFER *buffer, char *fmt, ...)
    
   return res;
 }
-
-char *strdup(const char *s)
-{
-  char *pstr;
-  int len;
-
-  len = strlen(s) + 1;
-  pstr = (char *) calloc(1, len);
-  strcpy(pstr, s);
-
-  return pstr;
-}


### PR DESCRIPTION
The following functions:

char   *strdup                ( const char *s );	
int     strcasecmp            ( const char *s1, const char *s2 );

are part of libc, so this patch removes them from the codebase.