### PR TITLE
Adding end to end testing with expect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ src/libguildmud.a: $(OBJ_FILES)
 .c.o: all
 	@$(CC) -c $(C_FLAGS) -o $@ $<
 
+telnet-test:
+	@echo "Requires guildmud to be running"
+	@cd tests/ && find . -maxdepth 1 -name '*.tcl' -exec {} \; && cd ..
+
 test: $(CHECK_FILES_EXE)
 	@find tests/ -maxdepth 1 -name '*.run' -exec {} \;
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ src/libguildmud.a: $(OBJ_FILES)
 .c.o: all
 	@$(CC) -c $(C_FLAGS) -o $@ $<
 
-
 test: $(CHECK_FILES_EXE)
 	@find tests/ -maxdepth 1 -name '*.run' -exec {} \;
 
@@ -43,7 +42,7 @@ install:
 .PHONY: clean
 clean:
 	@echo Cleaning code ...
-	@rm -rf src/*.o src/guildmud src/libguildmud.a src/*~ tests/*.c tests/run* tests/*.dSYM src/*.dSYM
+	@rm -rf src/*.o src/guildmud src/libguildmud.a src/*~ tests/*.c tests/*.run tests/*.dSYM src/*.dSYM
 	@rm -rf src/crypt_blowfish-1.3-mini/*.o src/crypt_blowfish-1.3-mini/*~ src/crypt_blowfish-1.3-mini/*a src/crypt_blowfish-1.3-mini/mini-test
 
 # Blowfish compilation rules

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "vagrant/provisioners/c.sh"
   config.vm.provision "shell", path: "vagrant/provisioners/sqlite.sh"
   config.vm.provision "shell", path: "vagrant/provisioners/check.sh"
+  config.vm.provision "shell", path: "vagrant/provisioners/expect.sh"
 
   # make /vagrant the working directory for all commands
   config.exec.commands '*', directory: '/vagrant'

--- a/tests/01-create_user.tcl
+++ b/tests/01-create_user.tcl
@@ -1,0 +1,35 @@
+#!/usr/bin/env expect 
+
+send_user "Running expect: $argv0\n" 
+
+log_user 0
+
+set user "testuser"
+set password "testuser"
+set server "localhost"
+set port "9009"
+
+# 1|Testuser|$2y$12$PnLEkiA888KDMlRcVDtql.BVvTKyJ.6y9epr3xUVoSbTGDCHNf/3y|2
+
+exec sqlite3 ../data/guildmud.db "delete from players where name='Testuser';"
+
+spawn telnet $server $port
+
+expect "name? "
+send "$user\r"
+expect "password: "
+send "$password\n"
+expect "password: "
+send "$password\n"
+
+expect {
+    "Welcome to SocketMUD(tm)" { 
+        send "quit\r"
+        send_user "100%: Checks: 1, Failures: 0, Errors: 0\n"
+        exit 0
+    }
+    default {
+        send_user "100%: Checks: 0, Failures: 1, Errors: 0\n"
+        exit 1
+    }
+}

--- a/tests/02-login.tcl
+++ b/tests/02-login.tcl
@@ -1,0 +1,31 @@
+#!/usr/bin/env expect 
+
+send_user "Running expect: $argv0\n" 
+
+log_user 0
+
+set user "testuser"
+set password "testuser"
+set server "localhost"
+set port "9009"
+
+
+spawn telnet $server $port
+
+expect "name? "
+send "$user\r"
+expect "password? "
+send "$password\n"
+
+
+expect {
+    "You take over a body already in use." { 
+        send "quit\r"
+        send_user "100%: Checks: 1, Failures: 0, Errors: 0\n"
+        exit 0
+    }
+    default {
+        send_user "100%: Checks: 0, Failures: 1, Errors: 0\n"
+        exit 1
+    }
+}

--- a/tests/03-login-fail.tcl
+++ b/tests/03-login-fail.tcl
@@ -1,0 +1,30 @@
+#!/usr/bin/env expect 
+
+send_user "Running expect: $argv0\n" 
+
+log_user 0
+
+set user "testuser"
+set bad_password "xxx"
+set server "localhost"
+set port "9009"
+
+
+spawn telnet $server $port
+
+expect "name? "
+send "$user\r"
+expect "password? "
+send "$bad_password\n"
+
+
+expect {
+    "Bad password!" { 
+        send_user "100%: Checks: 1, Failures: 0, Errors: 0\n"
+        exit 0
+    }
+    default {
+        send_user "100%: Checks: 0, Failures: 1, Errors: 0\n"
+        exit 1
+    }
+}

--- a/tests/04-check-command-help.tcl
+++ b/tests/04-check-command-help.tcl
@@ -1,0 +1,39 @@
+#!/usr/bin/env expect 
+
+
+send_user "Running expect: $argv0\n" 
+
+log_user 0
+
+set user "testuser"
+set password "testuser"
+set server "localhost"
+set port "9009"
+
+spawn telnet $server $port
+
+expect "name? "
+send "$user\r"
+expect "password? "
+send "$password\n"
+
+
+expect {
+    "SocketMud:> " {
+        send "help\r"
+        expect { 
+            "HELP FILES" {
+                send_user "100%: Checks: 1, Failures: 0, Errors: 0\n"
+                exit 0
+            }
+            default {
+                send_user "100%: Checks: 0, Failures: 1, Errors: 0\n"
+                exit 1
+            }
+        }
+    }
+    default {
+        send_user "100%: Checks: 0, Failures: 1, Errors: 0\n"
+        exit 1
+    }
+}

--- a/vagrant/provisioners/expect.sh
+++ b/vagrant/provisioners/expect.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt-get update -y
+apt-get install -y expect


### PR DESCRIPTION
First PR that to add [expect](https://core.tcl.tk/expect/index) end to end testing. It adds a new rule to Makefile (test-telnet) so tests can be run from the command line.

The tests use [expect](https://core.tcl.tk/expect/index) to connect to guildmud. That means that guildmud must be compiled and running before the tests can be run. There are 4 tests:

**01-create_user.tcl** goes through the create user process and adds a new user (testuser) that's used by the remaining scripts. To ensure testuser is not created, it calls sqlite3 to remove the testuser if exists. That means this script needs to have access to the data/guildmud.db file.
**02-login.tcl** using testuser created by the previous scripts logs into guildmud.
**03-login-fail.tcl** tries to log in using an incorrect password. It checks the password routines works fails with an incorrect password.	
**04-check-command-help.tcl** logins using testuser and runs the help command.

Also, the patch adds the Vagrant infrastructure so expect works.

Once this is applied let's discuss how to update Makefile to add this to the Travis pipeline.

