### PR TITLE
Add C99 stdbool.h to the codebase.

### DIFF
--- a/src/action_safe.c
+++ b/src/action_safe.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 /* include main header file */
 #include "mud.h"
@@ -31,12 +32,12 @@ void cmd_quit(D_MOBILE *dMob, char *arg)
 
   dMob->socket->player = NULL;
   free_mobile(dMob);
-  close_socket(dMob->socket, FALSE);
+  close_socket(dMob->socket, false);
 }
 
 void cmd_shutdown(D_MOBILE *dMob, char *arg)
 {
-  shut_down = TRUE;
+  shut_down = true;
 }
 
 void cmd_commands(D_MOBILE *dMob, char *arg)
@@ -128,7 +129,7 @@ void cmd_compress(D_MOBILE *dMob, char *arg)
   }
   else /* disable compression */
   {
-    if (!compressEnd(dMob->socket, dMob->socket->compressing, FALSE))
+    if (!compressEnd(dMob->socket, dMob->socket->compressing, false))
     {
       text_to_mobile(dMob, "Failed.\n\r");
       return;
@@ -162,12 +163,12 @@ void cmd_copyover(D_MOBILE *dMob, char *arg)
   AttachIterator(&Iter, dsock_list);
   while ((dsock = (D_SOCKET *) NextInList(&Iter)) != NULL)
   {
-    compressEnd(dsock, dsock->compressing, FALSE);
+    compressEnd(dsock, dsock->compressing, false);
 
     if (dsock->state != STATE_PLAYING)
     {
       text_to_socket(dsock, "\n\rSorry, we are rebooting. Come back in a few minutes.\n\r");
-      close_socket(dsock, FALSE);
+      close_socket(dsock, false);
     }
     else
     {
@@ -205,7 +206,7 @@ void cmd_linkdead(D_MOBILE *dMob, char *arg)
   D_MOBILE *xMob;
   ITERATOR Iter;
   char buf[MAX_BUFFER];
-  bool found = FALSE;
+  bool found = false;
 
   AttachIterator(&Iter, dmobile_list);
   while ((xMob = (D_MOBILE *) NextInList(&Iter)) != NULL)
@@ -214,7 +215,7 @@ void cmd_linkdead(D_MOBILE *dMob, char *arg)
     {
       snprintf(buf, MAX_BUFFER, "%s is linkdead.\n\r", xMob->name);
       text_to_mobile(dMob, buf);
-      found = TRUE;
+      found = true;
     }
   }
   DetachIterator(&Iter);

--- a/src/db.c
+++ b/src/db.c
@@ -2,6 +2,7 @@
 #include <sqlite3.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 /* main header file */
 #include "mud.h"
@@ -18,10 +19,10 @@ bool db_open()
 
     db_close();
 
-    return FALSE;
+    return false;
   }
 
-  return TRUE;
+  return true;
 }
 
 bool db_close()
@@ -30,10 +31,10 @@ bool db_close()
   {
     bug("Unable to close database: %s", sqlite3_errmsg(db));
 
-    return FALSE;
+    return false;
   }
 
-  return TRUE;
+  return true;
 }
 
 bool db_execute(const char *sql, ...)
@@ -48,23 +49,23 @@ bool db_execute(const char *sql, ...)
   va_end(vars);
 
   if ( stmt == NULL ) {
-    return FALSE;
+    return false;
   }
 
 
   if ( db_step(stmt) != SQLITE_DONE ) {
     bug("Failed to step through statement: %s", sqlite3_errmsg(db));
 
-    return FALSE;
+    return false;
   }
 
   if ( db_finalize(stmt) != SQLITE_OK ) {
     bug("Failed to finalize statement: %s", sqlite3_errmsg(db));
 
-    return FALSE;
+    return false;
   }
 
-  return TRUE;
+  return true;
 }
 
 sqlite3_stmt *db_prepare(const char *sql, ...)

--- a/src/event-handler.c
+++ b/src/event-handler.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdbool.h>
+
 
 /* include main header file */
 #include "mud.h"
@@ -28,7 +30,7 @@ bool enqueue_event(EVENT_DATA *event, int game_pulses)
   if (event->ownertype == EVENT_UNOWNED)
   {
     bug("enqueue_event: event type %d with no owner.", event->type);
-    return FALSE;
+    return false;
   }
 
   /* An event must be enqueued into the future */
@@ -49,7 +51,7 @@ bool enqueue_event(EVENT_DATA *event, int game_pulses)
   AttachToList(event, eventqueue[bucket]);
 
   /* success */
-  return TRUE;
+  return true;
 }
 
 /* function   :: dequeue_event()
@@ -181,7 +183,7 @@ void heartbeat()
      *
      * bool event_function ( EVENT_DATA *event );
      *
-     * Any event returning TRUE is not dequeued, it is assumed
+     * Any event returning true is not dequeued, it is assumed
      * that the event has dequeued itself.
      */
     if (!((*event->fun)(event)))
@@ -221,7 +223,7 @@ void add_event_mobile(EVENT_DATA *event, D_MOBILE *dMob, int delay)
   AttachToList(event, dMob->events);
 
   /* attempt to enqueue the event */
-  if (enqueue_event(event, delay) == FALSE)
+  if (enqueue_event(event, delay) == false)
     bug("add_event_mobile: event type %d failed to be enqueued.", event->type);
 }
 
@@ -256,7 +258,7 @@ void add_event_socket(EVENT_DATA *event, D_SOCKET *dSock, int delay)
   AttachToList(event, dSock->events);
 
   /* attempt to enqueue the event */
-  if (enqueue_event(event, delay) == FALSE)
+  if (enqueue_event(event, delay) == false)
     bug("add_event_socket: event type %d failed to be enqueued.", event->type);
 }
 
@@ -290,7 +292,7 @@ void add_event_game(EVENT_DATA *event, int delay)
   AttachToList(event, global_events);
 
   /* attempt to enqueue the event */
-  if (enqueue_event(event, delay) == FALSE)
+  if (enqueue_event(event, delay) == false)
     bug("add_event_game: event type %d failed to be enqueued.", event->type);
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 /* include main header file */
 #include "mud.h"
@@ -28,7 +29,7 @@ bool event_game_tick(EVENT_DATA *event)
   event->type = EVENT_GAME_TICK;
   add_event_game(event, 10 * 60 * PULSES_PER_SECOND);
 
-  return FALSE;
+  return false;
 }
 
 bool event_mobile_save(EVENT_DATA *event)
@@ -36,13 +37,13 @@ bool event_mobile_save(EVENT_DATA *event)
   D_MOBILE *dMob;
 
   /* Check to see if there is an owner of this event.
-   * If there is no owner, we return TRUE, because
+   * If there is no owner, we return true, because
    * it's the safest - and post a bug message.
    */
   if ((dMob = event->owner.dMob) == NULL)
   {
     bug("event_mobile_save: no owner.");
-    return TRUE;
+    return true;
   }
 
   /* save the actual player file */
@@ -54,7 +55,7 @@ bool event_mobile_save(EVENT_DATA *event)
   event->type = EVENT_MOBILE_SAVE;
   add_event_mobile(event, dMob, 2 * 60 * PULSES_PER_SECOND);
 
-  return FALSE;
+  return false;
 }
 
 bool event_socket_idle(EVENT_DATA *event)
@@ -62,22 +63,22 @@ bool event_socket_idle(EVENT_DATA *event)
   D_SOCKET *dSock;
 
   /* Check to see if there is an owner of this event.
-   * If there is no owner, we return TRUE, because
+   * If there is no owner, we return true, because
    * it's the safest - and post a bug message.
    */
   if ((dSock = event->owner.dSock) == NULL)
   {
     bug("event_socket_idle: no owner.");
-    return TRUE;
+    return true;
   }
 
   /* tell the socket that it has idled out, and close it */
   text_to_socket(dSock, "You have idled out...\n\n\r");
-  close_socket(dSock, FALSE);
+  close_socket(dSock, false);
 
   /* since we closed the socket, all events owned
    * by that socket has been dequeued, and we need
-   * to return TRUE, so the caller knows this.
+   * to return true, so the caller knows this.
    */
-  return TRUE;
+  return true;
 }

--- a/src/gmcp.c
+++ b/src/gmcp.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
+
 #include "mud.h"
 
 const unsigned char gmcp_head [] = { IAC, SB, TELOPT_GMCP, 0 };
@@ -14,7 +16,7 @@ const unsigned char gmcp_tail [] = { IAC, SE, 0 };
 
 bool gmcpEnable(D_S *dsock)
 {
-  dsock->gmcp_enabled = TRUE;
+  dsock->gmcp_enabled = true;
   gmcpSend(dsock, "Test data");
   return dsock->gmcp_enabled;
 }
@@ -22,12 +24,12 @@ bool gmcpEnable(D_S *dsock)
 bool gmcpSend(D_S *dsock, const char *data)
 {
   if (!dsock->gmcp_enabled)
-    return FALSE;
+    return false;
 
   text_to_socket(dsock, (char *)  gmcp_head);
   text_to_socket(dsock, (char *)  data);
   text_to_socket(dsock, (char *)  gmcp_tail);
-  return TRUE;
+  return true;
 }
 
 void gmcpReceived(D_S *dsock)

--- a/src/help.c
+++ b/src/help.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <time.h>
 #include <dirent.h> 
+#include <stdbool.h>
+
 
 /* include main header file */
 #include "mud.h"
@@ -39,7 +41,7 @@ bool check_help(D_MOBILE *dMob, char *helpfile)
   ITERATOR Iter;
   char buf[MAX_HELP_ENTRY + 80];
   char *entry, *hFile;
-  bool found = FALSE;
+  bool found = false;
 
   hFile = capitalize(helpfile);
 
@@ -48,7 +50,7 @@ bool check_help(D_MOBILE *dMob, char *helpfile)
   {
     if (is_prefix(helpfile, pHelp->keyword))
     {
-      found = TRUE;
+      found = true;
       break;
     }
   }
@@ -67,10 +69,10 @@ bool check_help(D_MOBILE *dMob, char *helpfile)
   {
     /* helpfiles do not contain double dots (no moving out of the helpdir) */
     if (strstr(hFile, "..") != NULL)
-      return FALSE;
+      return false;
 
     if ((entry = read_help_entry(hFile)) == NULL)
-      return FALSE;
+      return false;
     else
     {
       if ((pHelp = (HELP_DATA *) malloc(sizeof(*pHelp))) == NULL)
@@ -88,7 +90,7 @@ bool check_help(D_MOBILE *dMob, char *helpfile)
   snprintf(buf, MAX_HELP_ENTRY + 80, "=== %s ===\n\r%s", pHelp->keyword, pHelp->text);
   text_to_mobile(dMob, buf);
 
-  return TRUE;
+  return true;
 }
 
 /*

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3,6 +3,7 @@
  */
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 /* include main header file */
 #include "mud.h"
@@ -11,7 +12,7 @@ void handle_cmd_input(D_SOCKET *dsock, char *arg)
 {
   D_MOBILE *dMob;
   char command[MAX_BUFFER];
-  bool found_cmd = FALSE;
+  bool found_cmd = false;
   int i;
 
   if ((dMob = dsock->player) == NULL)
@@ -25,7 +26,7 @@ void handle_cmd_input(D_SOCKET *dsock, char *arg)
 
     if (is_prefix(command, tabCmd[i].cmd_name))
     {
-      found_cmd = TRUE;
+      found_cmd = true;
       (*tabCmd[i].cmd_funct)(dMob, arg);
     }
   }

--- a/src/io.c
+++ b/src/io.c
@@ -9,6 +9,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 /* include main header file */
 #include "mud.h"
@@ -176,7 +177,7 @@ char *fread_line(FILE *fp)
 int fread_number(FILE *fp)
 {
   int c, number = 0;
-  bool negative = FALSE;
+  bool negative = false;
 
   /* initial read */
   c = getc(fp);
@@ -192,7 +193,7 @@ int fread_number(FILE *fp)
     abort();
   }
   else if (c == '-')
-    negative = TRUE;
+    negative = true;
   else if (!isdigit(c))
   {
     bug("Fread_number: Not a number.");

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include <time.h>
 #include <sys/ioctl.h>
 #include <errno.h>
+#include <stdbool.h>
 
 /* including main header file */
 #include "mud.h"
@@ -46,10 +47,10 @@ int main(int argc, char **argv)
 
   if (argc > 2 && !strcmp(argv[argc-1], "copyover") && atoi(argv[argc-2]) > 0)
   {
-    fCopyOver = TRUE;
+    fCopyOver = true;
     control = atoi(argv[argc-2]);
   }
-  else fCopyOver = FALSE;
+  else fCopyOver = false;
 
   /* initialize the socket */
   if (!fCopyOver)

--- a/src/mud.h
+++ b/src/mud.h
@@ -18,14 +18,6 @@
  * Standard definitions *
  ************************/
 
-/* define TRUE and FALSE */
-#ifndef FALSE
-#define FALSE   0
-#endif
-#ifndef TRUE
-#define TRUE    1
-#endif
-
 #define eTHIN   0
 #define eBOLD   1
 
@@ -65,7 +57,6 @@
 #define COMM_LOG              10  /* admins only                     */
 
 /* define simple types */
-typedef  unsigned char     bool;
 typedef  short int         sh_int;
 
 
@@ -78,14 +69,14 @@ typedef  short int         sh_int;
  ***********************/
 
 #define UMIN(a, b)		((a) < (b) ? (a) : (b))
-#define IS_ADMIN(dMob)          ((dMob->level) > LEVEL_PLAYER ? TRUE : FALSE)
+#define IS_ADMIN(dMob)          ((dMob->level) > LEVEL_PLAYER ? true : false)
 #define IREAD(sKey, sPtr)             \
 {                                     \
   if (!strcasecmp(sKey, word))        \
   {                                   \
     int sValue = fread_number(fp);    \
     sPtr = sValue;                    \
-    found = TRUE;                     \
+    found = true;                     \
     break;                            \
   }                                   \
 }
@@ -94,7 +85,7 @@ typedef  short int         sh_int;
   if (!strcasecmp(sKey, word))        \
   {                                   \
     sPtr = fread_string(fp);          \
-    found = TRUE;                     \
+    found = true;                     \
     break;                            \
   }                                   \
 }

--- a/src/save.c
+++ b/src/save.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdbool.h>
 
 /* main header file */
 #include "mud.h"

--- a/src/strings.c
+++ b/src/strings.c
@@ -7,6 +7,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 /* include main header file */
 #include "mud.h"
@@ -17,20 +18,20 @@
 bool is_prefix(const char *aStr, const char *bStr)
 {
   /* NULL strings never compares */
-  if (aStr == NULL || bStr == NULL) return FALSE;
+  if (aStr == NULL || bStr == NULL) return false;
 
   /* empty strings never compares */
-  if (aStr[0] == '\0' || bStr[0] == '\0') return FALSE;
+  if (aStr[0] == '\0' || bStr[0] == '\0') return false;
 
   /* check if aStr is a prefix of bStr */
   while (*aStr)
   {
     if (tolower(*aStr++) != tolower(*bStr++))
-      return FALSE;
+      return false;
   }
 
   /* success */
-  return TRUE;
+  return true;
 }
 
 char *one_arg(char *fStr, char *bStr)

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,13 +8,15 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <stdbool.h>
+
 
 /* include main header file */
 #include "mud.h"
 
 /*
  * Check to see if a given name is
- * legal, returning FALSE if it
+ * legal, returning false if it
  * fails our high standards...
  */
 bool check_name(const char *name)
@@ -22,12 +24,12 @@ bool check_name(const char *name)
   int size, i;
 
   if ((size = strlen(name)) < 3 || size > 12)
-    return FALSE;
+    return false;
 
   for (i = 0 ;i < size; i++)
-    if (!isalpha(name[i])) return FALSE;
+    if (!isalpha(name[i])) return false;
 
-  return TRUE;
+  return true;
 }
 
 void clear_mobile(D_MOBILE *dMob)
@@ -183,19 +185,19 @@ void copyover_recover()
     }
     else /* ah bugger */
     {
-      close_socket(dsock, FALSE);
+      close_socket(dsock, false);
       continue;
     }
 
     /* Write something, and check if it goes error-free */
     if (!text_to_socket(dsock, "\n\r <*>  And before you know it, everything has changed  <*>\n\r"))
     {
-      close_socket(dsock, FALSE);
+      close_socket(dsock, false);
       continue;
     }
 
     /* make sure the socket can be used */
-    dsock->bust_prompt    =  TRUE;
+    dsock->bust_prompt    =  true;
     dsock->lookup_status  =  TSTATE_DONE;
     dsock->state          =  STATE_PLAYING;
 
@@ -218,7 +220,7 @@ D_MOBILE *check_reconnect(char *player)
     {
       if (dMob->socket)
       {
-        close_socket(dMob->socket, TRUE);
+        close_socket(dMob->socket, true);
       }
 
       break;

--- a/tests/test_crypt.test
+++ b/tests/test_crypt.test
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <check.h>
+#include <stdbool.h>
 
 #include "mud.h"
 

--- a/tests/test_list.test
+++ b/tests/test_list.test
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <check.h>
+#include <stdbool.h>
 
 #include "mud.h"
 

--- a/tests/test_stack.test
+++ b/tests/test_stack.test
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <check.h>
+#include <stdbool.h>
 
 #include "mud.h"
 

--- a/tests/test_strings.test
+++ b/tests/test_strings.test
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <check.h>
+#include <stdbool.h>
 
 #include "mud.h"
 
@@ -12,12 +13,12 @@
 #tcase check_is_prefix
 
 #test is_prefix_A_A
-    ck_assert_msg(TRUE == is_prefix("A", "A"), "is_prefix A, A should have returned true");
+    ck_assert_msg(true == is_prefix("A", "A"), "is_prefix A, A should have returned true");
 #test is_prefix_A_AA
-    ck_assert_msg(TRUE == is_prefix("A", "AA"), "is_prefix A, AA should have returned true");
+    ck_assert_msg(true == is_prefix("A", "AA"), "is_prefix A, AA should have returned true");
 #test is_prefix_A_AAA
-    ck_assert_msg(TRUE == is_prefix("A", "AAA"), "is_prefix A, AAA should have returned true");
+    ck_assert_msg(true == is_prefix("A", "AAA"), "is_prefix A, AAA should have returned true");
 #test is_prefix_A_AAAZ
-    ck_assert_msg(TRUE == is_prefix("A", "AAAZ"), "is_prefix A, AAAZ should have returned true");
+    ck_assert_msg(true == is_prefix("A", "AAAZ"), "is_prefix A, AAAZ should have returned true");
 #test is_prefix_A_B_fail
-    ck_assert_msg(TRUE != is_prefix("A", "B"), "is_prefix A, B should have returned false");
+    ck_assert_msg(true != is_prefix("A", "B"), "is_prefix A, B should have returned false");

--- a/tests/test_utils.test
+++ b/tests/test_utils.test
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <check.h>
+#include <stdbool.h>
 
 #include "mud.h"
 
@@ -12,16 +13,16 @@
 #tcase check_name
 
 #test check_name_valid
-    ck_assert_msg(TRUE == check_name("abc"), "check_name abc must not fail is an alpha string >=3 and <=12");
-    ck_assert_msg(TRUE == check_name("ALFA"), "check_name ALFA must not fail is an alpha string >=3 and <=12");
-    ck_assert_msg(TRUE == check_name("OMEGA"), "check_name OMEGA must not fail is an alpha string >=3 and <=12");
-    ck_assert_msg(TRUE == check_name("first"), "check_name first must not fail is an alpha string >=3 and <=12");
-    ck_assert_msg(TRUE == check_name("second"), "check_name second must not fail is an alpha string >=3 and <=12");
-    ck_assert_msg(TRUE == check_name("abcdefghijkl"), "check_name abcdefghijkl must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(true == check_name("abc"), "check_name abc must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(true == check_name("ALFA"), "check_name ALFA must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(true == check_name("OMEGA"), "check_name OMEGA must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(true == check_name("first"), "check_name first must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(true == check_name("second"), "check_name second must not fail is an alpha string >=3 and <=12");
+    ck_assert_msg(true == check_name("abcdefghijkl"), "check_name abcdefghijkl must not fail is an alpha string >=3 and <=12");
 
 #test check_name_fail
-    ck_assert_msg(FALSE == check_name("guild mud"), "check_name /guild mud/ must fail because has an /space/");
-    ck_assert_msg(FALSE == check_name("ab"), "check_name /ab/ must fail because has less < 3 characters");
-    ck_assert_msg(FALSE == check_name("abcdefghijklm"), "check_name /abcdefghijklm/ must fail because has > 13 chars");
-    ck_assert_msg(FALSE == check_name("guild*mud"), "check_name /guild*mud/ must fail because has an /*/");
-    ck_assert_msg(FALSE == check_name("guild1mud"), "check_name /guild1mud/ must fail because has an /1/");
+    ck_assert_msg(false == check_name("guild mud"), "check_name /guild mud/ must fail because has an /space/");
+    ck_assert_msg(false == check_name("ab"), "check_name /ab/ must fail because has less < 3 characters");
+    ck_assert_msg(false == check_name("abcdefghijklm"), "check_name /abcdefghijklm/ must fail because has > 13 chars");
+    ck_assert_msg(false == check_name("guild*mud"), "check_name /guild*mud/ must fail because has an /*/");
+    ck_assert_msg(false == check_name("guild1mud"), "check_name /guild1mud/ must fail because has an /1/");


### PR DESCRIPTION
Guildmud uses its own bool type. Because we're now expecting a C99 compiler, I changed all existing references to guildmud own bool type to the standard C99 <stdbool.h> type.

This will make slightly easier programme the persistence layer.

It changes almost all the files (including the ones in tests/ directory), but the changes are trivial:

1. Add #include <stdbool.h> in *.c files.
2. Change TRUE for true and FALSE for false in *.{c,h} files.
3. Remove ifdefs TRUE/FALSE from mud.h
