### PR TITLE
Create db.h and db schema update logic

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -1,0 +1,23 @@
+/* file: db.h
+ *
+ * Headerfile for sqlite interface
+ */
+
+#ifndef _DB_HEADER
+#define _DB_HEADER
+
+#include <sqlite3.h>
+#include <stdbool.h>
+
+/*
+ * db.c
+ */
+bool           db_open        ( void );
+bool           db_close       ( void );
+bool           db_execute     ( const char *sql, ... );
+sqlite3_stmt  *db_prepare     (const char *sql, ...);
+int            db_step        (sqlite3_stmt *stmt);
+int            db_finalize    (sqlite3_stmt *stmt);
+void           db_migrate     ( void );
+  
+#endif

--- a/src/mud.h
+++ b/src/mud.h
@@ -13,6 +13,7 @@
 #include "list.h"
 #include "stack.h"
 #include "crypt_blowfish-1.3-mini/ow-crypt.h"
+#include "db.h"
 
 /************************
  * Standard definitions *
@@ -317,16 +318,6 @@ void  save_player             ( D_M *dMob );
 D_M  *load_player             ( char *player );
 D_M  *load_profile            ( char *player );
 
-/*
- * db.c
- */
-bool           db_open        ( void );
-bool           db_close       ( void );
-bool           db_execute     ( const char *sql, ... );
-sqlite3_stmt  *db_prepare     (const char *sql, ...);
-int            db_step        (sqlite3_stmt *stmt);
-int            db_finalize    (sqlite3_stmt *stmt);
-void           db_migrate     ( void );
 
 /*******************************
  * End of prototype declartion *

--- a/src/save.c
+++ b/src/save.c
@@ -7,6 +7,7 @@
 
 /* main header file */
 #include "mud.h"
+#include "db.h"
 
 void save_player(D_MOBILE *dMob)
 {


### PR DESCRIPTION
First path for the [Persistence solution](https://github.com/mudcoders/guildmud/issues/35).

1. It moves the db definitions to a different include file (db.h)
2. Updates db_migrate() in db.c so guildmud updates the db to the latest release on startup.
3. As part of (2) we add to the database the NEXT_ID filed to have a single generator of id for all the objects the mud will manage. This will be used in the following persistence PR.